### PR TITLE
Fix/rawrepresentable codable

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: swift
+os: osx
+osx_image: xcode13.2
+script:
+  - swift build
+  - swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,14 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "UserDefault",
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v12)
+    ],
     products: [
         .library(
             name: "UserDefault",

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -1,0 +1,50 @@
+//
+//  Logger.swift
+//  UserDefault
+//
+//  Created by Ben Shutt on 13/01/2022.
+//
+
+import Foundation
+import OSLog
+
+extension OSLog {
+
+    /// App `OSLog` shared instance
+    static let logger = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "\(Logger.self)",
+        category: "UserDefault"
+    )
+}
+
+// MARK: - Logger
+
+/// Utility structure for logging messages
+struct Logger {
+
+    /// Log `message` on `logger` of `type`
+    ///
+    /// - Parameters:
+    ///   - message: `String`
+    ///   - type: `OSLogType`
+    ///   - logger: `OSLog`
+    static func log(
+        _ message: String,
+        type: OSLogType = .info,
+        logger: OSLog = .logger
+    ) {
+        os_log(type, log: logger, "%@", message)
+    }
+
+    /// Log `error` on `logger`
+    ///
+    /// - Parameters:
+    ///   - error: `Error`
+    ///   - logger: `OSLog`
+    static func log(
+        _ error: Error,
+        logger: OSLog = .logger
+    ) {
+        log("\(error)", type: .error, logger: logger)
+    }
+}

--- a/Sources/UserDefault.swift
+++ b/Sources/UserDefault.swift
@@ -37,7 +37,7 @@ public struct UserDefault<T> where T: UserDefaultElement {
                 return try T.read(object: obj)
             } catch {
                 // Error silenced to keep `wrappedValue` a get/set
-                debugPrint(error)
+                Logger.log(error)
                 return defaultValue
             }
         }
@@ -55,7 +55,7 @@ public struct UserDefault<T> where T: UserDefaultElement {
 
             } catch {
                 // Error silenced to keep `wrappedValue` a get/set
-                debugPrint(error)
+                Logger.log(error)
             }
         }
     }

--- a/Sources/UserDefaultElement/UserDefaultElement+RawRepresentable.swift
+++ b/Sources/UserDefaultElement/UserDefaultElement+RawRepresentable.swift
@@ -9,14 +9,16 @@
 import Foundation
 
 /// Define `UserDefaultElement` implementation when `Self` is `RawRepresentable`
-public extension UserDefaultElement where
-    Self: RawRepresentable,
-    RawValue: SupportedUserDefaultElement {
+public extension UserDefaultElement
+    where Self: RawRepresentable, RawValue: SupportedUserDefaultElement {
+
+    // MARK: - RawRepresentable
 
     /// Cast `object` as `RawValue` and initialize with that `RawValue`
     ///
     /// - Parameter object: `Any` object returned from the `UserDefaults`
-    static func read(object: Any) throws -> Self {
+    /// - Returns: `Self`
+    static func readRawRepresentable(object: Any) throws -> Self {
         // Cast to `RawValue`
         let rawValue: RawValue = try castOrThrow(object)
 
@@ -27,7 +29,49 @@ public extension UserDefaultElement where
     }
 
     /// Write `rawValue`
-    func write() throws -> Any {
+    /// - Returns: `Any`
+    func writeRawRepresentable() throws -> Any {
         return rawValue
+    }
+
+    // MARK: - UserDefaultElement
+
+    /// Alias to `readRawRepresentable(object:)`
+    ///
+    /// - Parameter object: `Any`
+    /// - Returns: `Self`
+    static func read(object: Any) throws -> Self {
+        return try readRawRepresentable(object: object)
+    }
+
+    /// Alias to `writeRawRepresentable()`
+    /// - Returns: `Any`
+    func write() throws -> Any {
+        return try writeRawRepresentable()
+    }
+}
+
+// MARK: - RawRepresentable + Codable
+
+/// Extension required to handle an entity which conforms to both:
+/// - `RawRepresentable`
+/// - `Codable`
+/// Otherwise conforming to `UserDefaultElement` raises an error as Swift doesn't know which
+/// implementation to use.
+public extension UserDefaultElement
+    where Self: RawRepresentable, RawValue: SupportedUserDefaultElement, Self: Codable {
+
+    /// Alias to `readRawRepresentable(object:)`
+    ///
+    /// - Parameter object: `Any`
+    /// - Returns: `Self`
+    static func read(object: Any) throws -> Self {
+        return try readRawRepresentable(object: object)
+    }
+
+    /// Alias to `writeRawRepresentable()`
+    /// - Returns: `Any`
+    func write() throws -> Any {
+        return try writeRawRepresentable()
     }
 }

--- a/Sources/UserDefaultElement/UserDefaultElement+RawRepresentable.swift
+++ b/Sources/UserDefaultElement/UserDefaultElement+RawRepresentable.swift
@@ -56,6 +56,7 @@ public extension UserDefaultElement
 /// Extension required to handle an entity which conforms to both:
 /// - `RawRepresentable`
 /// - `Codable`
+///
 /// Otherwise conforming to `UserDefaultElement` raises an error as Swift doesn't know which
 /// implementation to use.
 public extension UserDefaultElement

--- a/Tests/UserDefaultTests/UserDefaultTests.swift
+++ b/Tests/UserDefaultTests/UserDefaultTests.swift
@@ -2,11 +2,9 @@ import XCTest
 @testable import UserDefault
 
 final class UserDefaultTests: XCTestCase {
+
     func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(UserDefault().text, "Hello, World!")
+        XCTAssertTrue(true) // Update!
     }
 
     static var allTests = [

--- a/UserDefault.xcodeproj/project.pbxproj
+++ b/UserDefault.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		B80253852790990300B46B14 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80253842790990300B46B14 /* Logger.swift */; };
 		B8540EC625ADCC8E0004BA32 /* NotificationCenter+UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8540EC525ADCC8E0004BA32 /* NotificationCenter+UserDefault.swift */; };
 		B860C8C8256C30350015D59F /* Object+Null.swift in Sources */ = {isa = PBXBuildFile; fileRef = B860C8C7256C30350015D59F /* Object+Null.swift */; };
 		OBJ_32 /* CastError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* CastError.swift */; };
@@ -55,6 +56,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B80253842790990300B46B14 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		B8540EC525ADCC8E0004BA32 /* NotificationCenter+UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+UserDefault.swift"; sourceTree = "<group>"; };
 		B860C8C7256C30350015D59F /* Object+Null.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Object+Null.swift"; sourceTree = "<group>"; };
 		OBJ_10 /* RawRepresentableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawRepresentableError.swift; sourceTree = "<group>"; };
@@ -71,7 +73,7 @@
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_9 /* CastError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastError.swift; sourceTree = "<group>"; };
 		"UserDefault::UserDefault::Product" /* UserDefault.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UserDefault.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"UserDefault::UserDefaultTests::Product" /* UserDefaultTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = UserDefaultTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"UserDefault::UserDefaultTests::Product" /* UserDefaultTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = UserDefaultTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 				OBJ_11 /* UserDefault.swift */,
 				B860C8C7256C30350015D59F /* Object+Null.swift */,
 				B8540EC525ADCC8E0004BA32 /* NotificationCenter+UserDefault.swift */,
+				B80253842790990300B46B14 /* Logger.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -250,6 +253,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_32 /* CastError.swift in Sources */,
+				B80253852790990300B46B14 /* Logger.swift in Sources */,
 				OBJ_33 /* RawRepresentableError.swift in Sources */,
 				OBJ_34 /* UserDefault.swift in Sources */,
 				OBJ_35 /* Optional+UserDefaultElement.swift in Sources */,
@@ -306,9 +310,9 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = UserDefault.xcodeproj/UserDefault_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -363,9 +367,9 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = UserDefault.xcodeproj/UserDefault_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -447,9 +451,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = UserDefault.xcodeproj/UserDefaultTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -472,9 +474,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = UserDefault.xcodeproj/UserDefaultTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";


### PR DESCRIPTION
# Summary

Added extension required to handle an entity which conforms to both:
- `RawRepresentable`
- `Codable`

Otherwise conforming to `UserDefaultElement` raises an error as Swift doesn't know which
implementation to use.

# Change Type
Bug fix